### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test and Lint
+permissions:
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/jlurena/jlurena.me/security/code-scanning/1](https://github.com/jlurena/jlurena.me/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Specifically:
- `contents: write` is needed for the steps that push changes to the repository.
- Other permissions will default to `none`, ensuring no unnecessary access is granted.

The `permissions` block will be added after the `name` field (line 1) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
